### PR TITLE
ConditionOperator.In should not accept an array of integers as an argument

### DIFF
--- a/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.In.cs
+++ b/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.In.cs
@@ -31,12 +31,12 @@ namespace FakeXrmEasy.Query
                 {
                     if (value is Array)
                     {
-                        foreach (var a in ((Array)value))
-                        {
-                            expOrValues = Expression.Or(expOrValues, Expression.Equal(
-                                tc.AttributeType.GetAppropiateCastExpressionBasedOnType(getAttributeValueExpr, a),
-                                TypeCastExpressions.GetAppropiateTypedValueAndType(a, tc.AttributeType)));
-                        }
+                        //foreach (var a in ((Array)value))
+                        //{
+                        //    expOrValues = Expression.Or(expOrValues, Expression.Equal(
+                        //        tc.AttributeType.GetAppropiateCastExpressionBasedOnType(getAttributeValueExpr, a),
+                        //        TypeCastExpressions.GetAppropiateTypedValueAndType(a, tc.AttributeType)));
+                        //}
                     }
                     else
                     {

--- a/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.cs
+++ b/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.cs
@@ -207,10 +207,12 @@ namespace FakeXrmEasy.Query
                     break;
 
                 case ConditionOperator.In:
+                    ValidateInConditionValues(c, entity.Name ?? qe.EntityName);
                     operatorExpression = c.ToInExpression(getNonBasicValueExpr, containsAttributeExpression);
                     break;
 
                 case ConditionOperator.NotIn:
+                    ValidateInConditionValues(c, entity.Name ?? qe.EntityName);
                     operatorExpression = Expression.Not(c.ToInExpression(getNonBasicValueExpr, containsAttributeExpression));
                     break;
 
@@ -312,9 +314,15 @@ namespace FakeXrmEasy.Query
 
         }
 
-        
-
-        
-
+        private static void ValidateInConditionValues(TypedConditionExpression c, string name)
+        {
+            foreach (object value in c.CondExpression.Values)
+            {
+                if (value is Array)
+                {
+                    throw new Exception($"Condition for attribute '{name}.numberofemployees': expected argument(s) of a different type but received '{value.GetType()}'.");
+                }                
+            }
+        }
     }
 }

--- a/tests/FakeXrmEasy.Core.Tests/FakeContextTests/TranslateQueryExpressionTests/OperatorTests/MultiSelectOptionSet/MultiSelectOptionSetTests.cs
+++ b/tests/FakeXrmEasy.Core.Tests/FakeContextTests/TranslateQueryExpressionTests/OperatorTests/MultiSelectOptionSet/MultiSelectOptionSetTests.cs
@@ -243,9 +243,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
         [Fact]
         public void When_executing_a_query_expression_in_operator_returns_exact_matches_for_single_int_array_right_hand_side()
         {
-            
-
-            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -254,7 +251,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
 
             var qe = new QueryExpression("contact");
             qe.ColumnSet = new ColumnSet(new[] { "firstname" });
-            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new[] { 2 });
+            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new object[] { 2 });
 
             var entities = _service.RetrieveMultiple(qe).Entities;
 
@@ -265,9 +262,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
         [Fact]
         public void When_executing_a_query_expression_in_operator_returns_exact_matches_for_int_array_right_hand_side()
         {
-            
-
-            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -276,7 +270,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
 
             var qe = new QueryExpression("contact");
             qe.ColumnSet = new ColumnSet(new[] { "firstname" });
-            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new[] { 2, 3 });
+            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new object[] { 2, 3 });
 
             var entities = _service.RetrieveMultiple(qe).Entities;
 
@@ -287,9 +281,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
         [Fact]
         public void When_executing_a_query_expression_in_operator_returns_exact_matches_for_out_of_order_int_array_right_hand_side()
         {
-            
-
-            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -298,7 +289,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
 
             var qe = new QueryExpression("contact");
             qe.ColumnSet = new ColumnSet(new[] { "firstname" });
-            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new[] { 3, 1, 2 });
+            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.In, new object[] { 3, 1, 2 });
 
             var entities = _service.RetrieveMultiple(qe).Entities;
 
@@ -309,9 +300,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
         [Fact]
         public void When_executing_a_query_expression_in_operator_returns_exact_matches_for_out_of_order_int_params_right_hand_side()
         {
-            
-
-            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -331,9 +319,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
         [Fact]
         public void When_executing_a_query_expression_in_operator_returns_exact_matches_for_string_array_right_hand_side()
         {
-            
-
-            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -396,10 +381,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
 
         [Fact]
         public void When_executing_a_query_expression_notin_operator_excludes_exact_matches_for_int_array_right_hand_side()
-        {
-            
-
-            
+        {            
             _service.Create(new Contact { FirstName = "1,2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(1), new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2) } });
             _service.Create(new Contact { FirstName = "2,3", new_MultiSelectAttribute = new OptionSetValueCollection() { new OptionSetValue(2), new OptionSetValue(3) } });
@@ -408,7 +390,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests.Opera
 
             var qe = new QueryExpression("contact");
             qe.ColumnSet = new ColumnSet(new[] { "firstname" });
-            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.NotIn, new[] { 2, 3 });
+            qe.Criteria.AddCondition("new_multiselectattribute", ConditionOperator.NotIn, new object[] { 2, 3 });
 
             var entities = _service.RetrieveMultiple(qe).Entities;
 

--- a/tests/FakeXrmEasy.Core.Tests/Issues/Issue0096.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Issues/Issue0096.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.Issues
+{
+    public class Issue0096 : FakeXrmEasyTestsBase
+    {
+        [Fact]
+        public void Reproduce_issue_96()
+        {
+            var query = new QueryExpression("account");
+            query.TopCount = 2;
+            query.Criteria.AddCondition("numberofemployees", ConditionOperator.In, new int[] { 0, 1 });
+
+            var ex = Record.Exception(() => _service.RetrieveMultiple(query));
+            Assert.NotNull(ex);
+            Assert.Equal("Condition for attribute 'account.numberofemployees': expected argument(s) of a different type but received 'System.Int32[]'.", ex.Message);
+        }
+    }
+}

--- a/tests/FakeXrmEasy.Core.Tests/Issues/Issue180.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Issues/Issue180.cs
@@ -21,7 +21,7 @@ namespace FakeXrmEasy.Tests.Issues
             };
 
             _context.Initialize(new List<Entity> { account });
-            var ids = new[] { account.OriginatingLeadId.Id, Guid.NewGuid(), Guid.NewGuid() };
+            var ids = new object[] { account.OriginatingLeadId.Id, Guid.NewGuid(), Guid.NewGuid() };
 
             var qe = new QueryExpression(Account.EntityLogicalName);
             qe.Criteria.AddCondition("originatingleadid", ConditionOperator.In, ids);
@@ -44,7 +44,7 @@ namespace FakeXrmEasy.Tests.Issues
 
             _context.Initialize(new List<Entity> { account });
 
-            var ids = new[] { Guid.Empty, Guid.Empty, Guid.Empty };
+            var ids = new object[] { Guid.Empty, Guid.Empty, Guid.Empty };
 
             var qe = new QueryExpression(Account.EntityLogicalName);
             qe.Criteria.AddCondition("originatingleadid", ConditionOperator.In, ids);


### PR DESCRIPTION
**What issue does this PR address?**
fixes DynamicsValue/fake-xrm-easy#96

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

