### PR TITLE
Feature: Added support for ConditionOperator AboveOrEqual in a Condition Expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.5.2]
+
+### Added
+
+- **Alpha**: Initial support for AboveOrEqual in ConditionExpressions
+
 ## [2.5.1]
 
 ### Changed

--- a/src/FakeXrmEasy.Core/FakeXrmEasy.Core.csproj
+++ b/src/FakeXrmEasy.Core/FakeXrmEasy.Core.csproj
@@ -8,7 +8,7 @@
     <TargetFrameworks Condition="'$(Configuration)'=='FAKE_XRM_EASY_2013'">net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(Configuration)'=='FAKE_XRM_EASY'">net452</TargetFrameworks>
     <PackageId>FakeXrmEasy.Core</PackageId>
-    <VersionPrefix>2.5.1</VersionPrefix>
+    <VersionPrefix>2.5.2</VersionPrefix>
     <Authors>Jordi Montaña</Authors>
     <Company>Dynamics Value</Company>
     <Title>FakeXrmEasy Core</Title>
@@ -102,22 +102,22 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2013'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2015'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2016'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_365'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_9'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
 
   <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">

--- a/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.AboveOrEqual.cs
+++ b/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.AboveOrEqual.cs
@@ -1,0 +1,47 @@
+﻿using FakeXrmEasy.Abstractions;
+using FakeXrmEasy.Extensions;
+using FakeXrmEasy.Query;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FakeXrmEasy.Core.Query
+{
+    internal static partial class ConditionExpressionExtensions    
+    {
+        internal static Expression ToAboveOrEqualExpression(this TypedConditionExpression tc, Expression getAttributeValueExpr, Expression containsAttributeExpr, IXrmFakedContext context)
+        {
+            var c = tc.CondExpression;
+            var entityLogicalName = !string.IsNullOrEmpty(c.EntityName) ? c.EntityName : tc.QueryExpression.EntityName;
+            
+            if(!context.Relationships.Any(r => r.IsHierarchical && r.Entity1LogicalName.Equals(entityLogicalName) && r.Entity1Attribute.Equals(c.AttributeName)))
+            {
+                return tc.ToEqualExpression(context, getAttributeValueExpr, containsAttributeExpr);
+            }
+
+            //TODO recursive magic to get parent records from hierarchie
+            var hierarchicalRelationship = context.Relationships.FirstOrDefault(r => r.IsHierarchical && r.Entity1LogicalName.Equals(entityLogicalName) && r.Entity1Attribute.Equals(c.AttributeName));
+
+            var currentRecord = context.CreateQuery(entityLogicalName).FirstOrDefault(e => ((Guid)e.Attributes[c.AttributeName]) == ((Guid)c.Values[0]));            
+            RetrieveParentEntity(context, hierarchicalRelationship, currentRecord);            
+
+            return tc.ToEqualExpression(context, getAttributeValueExpr, containsAttributeExpr);
+        }
+
+        private static void RetrieveParentEntity(IXrmFakedContext context, XrmFakedRelationship hierarchicalRelationship, Entity currentRecord)
+        {
+            if (currentRecord == null || !currentRecord.Attributes.ContainsKey(hierarchicalRelationship.Entity2Attribute) || currentRecord.Attributes[hierarchicalRelationship.Entity2Attribute] == null)
+            {
+                return;
+            }
+
+            var parentRecord = context.CreateQuery(hierarchicalRelationship.Entity1LogicalName).FirstOrDefault(e => ((Guid)e.Attributes[hierarchicalRelationship.Entity1Attribute]) == ((EntityReference)currentRecord.Attributes[hierarchicalRelationship.Entity2Attribute]).Id);
+            RetrieveParentEntity(context, hierarchicalRelationship, parentRecord);            
+        }
+    }
+}

--- a/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.cs
+++ b/src/FakeXrmEasy.Core/Query/ConditionExpressionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Xrm.Sdk;
 using FakeXrmEasy.Extensions;
 using System;
 using FakeXrmEasy.Abstractions.Exceptions;
+using FakeXrmEasy.Core.Query;
 
 namespace FakeXrmEasy.Query
 {
@@ -285,6 +286,12 @@ namespace FakeXrmEasy.Query
 
                 case ConditionOperator.DoesNotContainValues:
                     operatorExpression = Expression.Not(c.ToContainsValuesExpression(getNonBasicValueExpr, containsAttributeExpression));
+                    break;
+#endif
+
+#if FAKE_XRM_EASY_365 || FAKE_XRM_EASY_9
+                case ConditionOperator.AboveOrEqual:
+                    operatorExpression = c.ToAboveOrEqualExpression(getNonBasicValueExpr, containsAttributeExpression, context);
                     break;
 #endif
 

--- a/tests/FakeXrmEasy.Core.Tests/FakeXrmEasy.Core.Tests.csproj
+++ b/tests/FakeXrmEasy.Core.Tests/FakeXrmEasy.Core.Tests.csproj
@@ -11,7 +11,7 @@
     <IsPackable>true</IsPackable>
 
     <PackageId>FakeXrmEasy.CoreTests</PackageId>
-    <VersionPrefix>2.5.1</VersionPrefix>
+    <VersionPrefix>2.5.2</VersionPrefix>
     <Authors>Jordi Montaña</Authors>
     <Company>Dynamics Value S.L.</Company>
     <Title>Internal Unit test suite for FakeXrmEasy.Core package</Title>
@@ -114,22 +114,22 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2013'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2015'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_2016'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_365'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='FAKE_XRM_EASY_9'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="[2.5.0-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="[2.5.1-*,3.0)" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(PackTests)' == ''">
@@ -137,22 +137,22 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY'">
-    <PackageReference Include="FakeXrmEasy.Core.v2011" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v2011" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2013'">
-    <PackageReference Include="FakeXrmEasy.Core.v2013" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v2013" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2015'">
-    <PackageReference Include="FakeXrmEasy.Core.v2015" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v2015" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2016'">
-    <PackageReference Include="FakeXrmEasy.Core.v2016" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v2016" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_365'">
-    <PackageReference Include="FakeXrmEasy.Core.v365" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v365" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_9'">
-    <PackageReference Include="FakeXrmEasy.Core.v9" Version="[2.5.1-*,3.0)" />
+    <PackageReference Include="FakeXrmEasy.Core.v9" Version="[2.5.2-*,3.0)" />
   </ItemGroup>
   
 


### PR DESCRIPTION
**What issue does this PR address?**
Added support for ConditionOperator AboveOrEqual in a Condition Expression. The condition operater can now be used in a query expression and will check the specified relations in the context to determine if there is any Hierarchical relationship. And walk through the parent-child structure.

Important: This change is depended on the PR in the abstractions project (https://github.com/DynamicsValue/fake-xrm-easy-abstractions/pull/58) to make use of the IsHierarchical property in a XrmFakedRelationship.

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 