### PR TITLE
feat(#141): add support for link entities using the exists join operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.7.0]
+
+### Added
+
+- Added support for link entities that use the `Exists` join operator - https://github.com/DynamicsValue/fake-xrm-easy/issues/141
+
 ## [2.6.0]
 
 ### Added

--- a/src/FakeXrmEasy.Core/FakeXrmEasy.Core.csproj
+++ b/src/FakeXrmEasy.Core/FakeXrmEasy.Core.csproj
@@ -25,6 +25,7 @@
 		<SignAssembly>True</SignAssembly>
     <PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
     <SonarQubeTestProject>False</SonarQubeTestProject>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FakeXrmEasy.Core/Query/LinkEntityQueryExtensions.cs
+++ b/src/FakeXrmEasy.Core/Query/LinkEntityQueryExtensions.cs
@@ -87,8 +87,16 @@ namespace FakeXrmEasy.Query
                                                             , (x, y) => x.outerEl
                                                                             .JoinAttributes(y, new ColumnSet(true), leAlias, context));
 
-
                     break;
+#if FAKE_XRM_EASY_9
+                case JoinOperator.Exists:
+                    // This is most likely not the most performant implementation, but it is probably the closest match
+                    // to the generated sql query, which will be a correlated subquery.
+                    query = query.Where(outerEl => 
+                        inner.Any(innerEl => 
+                            outerEl.KeySelector(linkFromAlias, context).Equals(innerEl.KeySelector(le.LinkToAttributeName, context))));
+                    break;
+#endif
                 default: //This shouldn't be reached as there are only 3 types of Join...
                     throw UnsupportedExceptionFactory.New(context.LicenseContext.Value, string.Format("The join operator {0} is currently not supported. ", le.JoinOperator));
 


### PR DESCRIPTION
Microsoft introduced new query operators that offer solutions for queries that check for conditions on linked entities, but do not require any data from them. They can offer performance benefits by reducing the result set size compared to regular joins, as the outer result rows will not be duplicated.

This is part of the larger issue #141.

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

