### PR TITLE
Enhance FetchXML processing by adding alias resolution for conditions and related tests

### DIFF
--- a/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
+++ b/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
@@ -325,12 +325,15 @@ namespace FakeXrmEasy.Extensions.FetchXml
         /// <returns></returns>
         public static FilterExpression ToCriteria(this XDocument xlDoc, IXrmFakedContext ctx)
         {
+            // Create a shared alias cache for this fetch evaluation
+            var aliasToEntityMap = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+
             return xlDoc.Elements()   //fetch
-                    .Elements()     //entity
-                    .Elements()     //child nodes of entity
-                    .Where(el => el.Name.LocalName.Equals("filter"))
-                    .Select(el => el.ToFilterExpression(ctx))
-                    .FirstOrDefault();
+                .Elements()     //entity
+                .Elements()     //child nodes of entity
+                .Where(el => el.Name.LocalName.Equals("filter"))
+                .Select(el => el.ToFilterExpression(ctx, aliasToEntityMap))
+                .FirstOrDefault();
         }
 
         /// <summary>
@@ -351,6 +354,79 @@ namespace FakeXrmEasy.Extensions.FetchXml
                 el = parent;
             }
 
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves a FetchXML alias to the actual entity name by finding the corresponding link-entity.
+        /// </summary>
+        /// <param name="el">The current element (typically a condition element).</param>
+        /// <param name="alias">The alias to resolve.</param>
+        /// <param name="aliasToEntityMap">Optional shared cache of alias-to-entity name mappings for the current fetch.</param>
+        /// <returns>The entity logical name for the alias, or null if not found.</returns>
+        public static string ResolveAliasToEntityName(this XElement el, string alias, Dictionary<string, string> aliasToEntityMap = null)
+        {
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                return null;
+            }
+
+            // Check cache first if provided
+            if (aliasToEntityMap != null && aliasToEntityMap.TryGetValue(alias, out var cachedEntityName))
+            {
+                return cachedEntityName;
+            }
+
+            // Traverse up to find the root fetch element
+            var current = el;
+            while (current != null && !current.Name.LocalName.Equals("fetch"))
+            {
+                current = current.Parent;
+            }
+            if (current == null)
+            {
+                return null;
+            }
+
+            // Try to find the alias in link-entity nodes
+            var linkEntity = current.Descendants()
+                .Where(e => e.Name.LocalName.Equals("link-entity"))
+                .FirstOrDefault(e =>
+                {
+                    var aliasAttr = e.GetAttribute("alias");
+                    return aliasAttr != null && aliasAttr.Value.Equals(alias, StringComparison.InvariantCultureIgnoreCase);
+                });
+            if (linkEntity != null)
+            {
+                var nameAttr = linkEntity.GetAttribute("name");
+                if (nameAttr != null)
+                {
+                    // Cache the result if cache dictionary is provided
+                    if (aliasToEntityMap != null)
+                    {
+                        aliasToEntityMap[alias] = nameAttr.Value;
+                    }
+                    return nameAttr.Value;
+                }
+            }
+
+            // If alias doesn't match any link-entity, it might be the entity name itself (no alias case)
+            var linkEntityByName = current.Descendants()
+                .Where(e => e.Name.LocalName.Equals("link-entity"))
+                .FirstOrDefault(e =>
+                {
+                    var nameAttr = e.GetAttribute("name");
+                    return nameAttr != null && nameAttr.Value.Equals(alias, StringComparison.InvariantCultureIgnoreCase);
+                });
+            if (linkEntityByName != null)
+            {
+                // Cache the result if cache dictionary is provided
+                if (aliasToEntityMap != null)
+                {
+                    aliasToEntityMap[alias] = alias;
+                }
+                return alias;
+            }
             return null;
         }
 
@@ -513,12 +589,13 @@ namespace FakeXrmEasy.Extensions.FetchXml
         }
 
         /// <summary>
-        /// Converts a <filter> FetchXml node into a FilterExpression
+        /// Converts a FetchXML filter node into a FilterExpression.
         /// </summary>
-        /// <param name="elem">Assumes the current element is a "filter" node</param>
-        /// <param name="ctx">The IXrmFakedContext</param>
-        /// <returns></returns>
-        public static FilterExpression ToFilterExpression(this XElement elem, IXrmFakedContext ctx)
+        /// <param name="elem">The current element, expected to be a filter node.</param>
+        /// <param name="ctx">The execution context.</param>
+        /// <param name="aliasToEntityMap">Optional shared cache of alias-to-entity name mappings for the current fetch.</param>
+        /// <returns>The constructed FilterExpression.</returns>
+        public static FilterExpression ToFilterExpression(this XElement elem, IXrmFakedContext ctx, Dictionary<string, string> aliasToEntityMap = null)
         {
             var filterExpression = new FilterExpression();
 
@@ -533,11 +610,17 @@ namespace FakeXrmEasy.Extensions.FetchXml
                                                   LogicalOperator.And : LogicalOperator.Or;
             }
 
+            // Build alias cache once if not provided
+            if (aliasToEntityMap == null)
+            {
+                aliasToEntityMap = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            }
+
             //Process other filters recursively
             var otherFilters = elem
                         .Elements() //child nodes of this filter
                         .Where(el => el.Name.LocalName.Equals("filter"))
-                        .Select(el => el.ToFilterExpression(ctx))
+                        .Select(el => el.ToFilterExpression(ctx, aliasToEntityMap))
                         .ToList();
 
 
@@ -545,7 +628,7 @@ namespace FakeXrmEasy.Extensions.FetchXml
             var conditions = elem
                         .Elements() //child nodes of this filter
                         .Where(el => el.Name.LocalName.Equals("condition"))
-                        .Select(el => el.ToConditionExpression(ctx))
+                        .Select(el => el.ToConditionExpression(ctx, aliasToEntityMap))
                         .ToList();
 
             #if FAKE_XRM_EASY_9
@@ -586,12 +669,13 @@ namespace FakeXrmEasy.Extensions.FetchXml
         }
 
         /// <summary>
-        /// 
+        /// Converts a FetchXML condition node into a ConditionExpression.
         /// </summary>
-        /// <param name="elem"></param>
-        /// <param name="ctx"></param>
-        /// <returns></returns>
-        public static ConditionExpression ToConditionExpression(this XElement elem, IXrmFakedContext ctx)
+        /// <param name="elem">The current element, expected to be a condition node.</param>
+        /// <param name="ctx">The execution context.</param>
+        /// <param name="aliasToEntityMap">Optional shared cache of alias-to-entity name mappings for the current fetch.</param>
+        /// <returns>The constructed ConditionExpression.</returns>
+        public static ConditionExpression ToConditionExpression(this XElement elem, IXrmFakedContext ctx, Dictionary<string, string> aliasToEntityMap = null)
         {
             var conditionExpression = new ConditionExpression();
 
@@ -798,16 +882,25 @@ namespace FakeXrmEasy.Extensions.FetchXml
             //Process values
             object[] values = null;
 
-
             var entityName = GetAssociatedEntityNameForConditionExpression(elem);
+
+            // When entityname is specified (alias or entity name), resolve it to the actual entity name for type lookup
+            var entityNameForTypeLookup = entityName;
+            if (!string.IsNullOrWhiteSpace(conditionEntityName))
+            {
+                var resolvedEntityName = elem.ResolveAliasToEntityName(conditionEntityName, aliasToEntityMap);
+                if (!string.IsNullOrWhiteSpace(resolvedEntityName))
+                {
+                    entityNameForTypeLookup = resolvedEntityName;
+                }
+            }
 
             //Find values inside the condition expression, if apply
             values = elem
                         .Elements() //child nodes of this filter
                         .Where(el => el.Name.LocalName.Equals("value"))
-                        .Select(el => el.ToValue(ctx, entityName, attributeName, op))
+                        .Select(el => el.ToValue(ctx, entityNameForTypeLookup, attributeName, op))
                         .ToArray();
-
 
             //Otherwise, a single value was used
             if (value != null)
@@ -815,15 +908,15 @@ namespace FakeXrmEasy.Extensions.FetchXml
 #if FAKE_XRM_EASY_2013 || FAKE_XRM_EASY_2015 || FAKE_XRM_EASY_2016 || FAKE_XRM_EASY_365 || FAKE_XRM_EASY_9
                 if (string.IsNullOrWhiteSpace(conditionEntityName))
                 {
-                    return new ConditionExpression(attributeName, op, GetConditionExpressionValueCast(value, ctx, entityName, attributeName, op));
+                    return new ConditionExpression(attributeName, op, GetConditionExpressionValueCast(value, ctx, entityNameForTypeLookup, attributeName, op));
                 }
                 else
                 {
-                    return new ConditionExpression(conditionEntityName, attributeName, op, GetConditionExpressionValueCast(value, ctx, entityName, attributeName, op));
+                    return new ConditionExpression(conditionEntityName, attributeName, op, GetConditionExpressionValueCast(value, ctx, entityNameForTypeLookup, attributeName, op));
                 }
 
 #else
-                return new ConditionExpression(attributeName, op, GetConditionExpressionValueCast(value, ctx, entityName, attributeName, op));
+                return new ConditionExpression(attributeName, op, GetConditionExpressionValueCast(value, ctx, entityNameForTypeLookup, attributeName, op));
            
 #endif
             }
@@ -841,9 +934,6 @@ namespace FakeXrmEasy.Extensions.FetchXml
 #else
             return new ConditionExpression(attributeName, op, values);
 #endif
-
-
-
         }
 
         /// <summary>

--- a/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/FetchXmlAliasedConditionTests.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/FetchXmlAliasedConditionTests.cs
@@ -1,0 +1,149 @@
+using Crm;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using FakeXrmEasy.Abstractions;
+using FakeXrmEasy.Middleware;
+using FakeXrmEasy.Middleware.Crud;
+using FakeXrmEasy.Abstractions.Enums;
+
+namespace FakeXrmEasy.Core.Tests.Query.FetchXml
+{
+    /// <summary>
+    /// Tests for FetchXML conditions with entityname attribute that references linked entity aliases
+    /// </summary>
+    public class FetchXmlAliasedConditionTests : FakeXrmEasyTestsBase
+    {
+        public FetchXmlAliasedConditionTests() : base()
+        {
+        }
+
+        /// <summary>
+        /// This test reproduces the bug where a FetchXML condition with entityname="alias"
+        /// fails when the attribute doesn't exist on the main entity but does exist on the linked entity.
+        /// 
+        /// The bug occurs because the attribute type lookup uses the parent entity name instead of
+        /// resolving the alias to the linked entity's name.
+        /// </summary>
+        [Fact]
+        public void FetchXml_WithEntityNameAlias_ShouldFilterOnLinkedEntity_NotMainEntity()
+        {
+            // This test uses Contact and Account entities from GeneratedCode.cs
+            // Contact will have an attribute that Account doesn't have
+            _context.EnableProxyTypes(Assembly.GetAssembly(typeof(Contact)));
+
+            // Create test data
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                Id = accountId,
+                Name = "Test Account"
+            };
+
+            var contactId = Guid.NewGuid();
+            var contact = new Contact
+            {
+                Id = contactId,
+                FirstName = "John",
+                LastName = "Doe",
+                // Contact has attributes that Account doesn't have
+                BirthDate = DateTime.Now.AddYears(-30)
+            };
+
+            // Link account to contact via ParentCustomerId (Contact can have parent account)
+            contact.ParentCustomerId = new EntityReference("account", accountId);
+
+            _context.Initialize(new List<Entity> { account, contact });
+
+            var service = _context.GetOrganizationService();
+
+            // FetchXML with entityname pointing to linked entity alias
+            // The condition filters on contact.birthdate using entityname="linkedContact"
+            // Account doesn't have birthdate attribute - only Contact does
+            var fetchXml = $@"
+                <fetch>
+                    <entity name='account'>
+                        <attribute name='name' />
+                        <filter>
+                            <condition attribute='birthdate' operator='not-null' 
+                                       entityname='linkedContact' />
+                        </filter>
+                        <link-entity name='contact' 
+                                     from='parentcustomerid' 
+                                     to='accountid' 
+                                     alias='linkedContact' 
+                                     link-type='inner'>
+                            <attribute name='firstname' />
+                            <attribute name='birthdate' />
+                        </link-entity>
+                    </entity>
+                </fetch>";
+
+            // This should succeed - the entityname="linkedContact" means check linkedContact.birthdate
+            // NOT account.birthdate. Account doesn't need to have the birthdate attribute.
+            var result = service.RetrieveMultiple(new FetchExpression(fetchXml));
+
+            Assert.Single(result.Entities);
+            Assert.Equal(accountId, result.Entities[0].Id);
+        }
+
+        /// <summary>
+        /// Test with entityname referencing entity name directly (not alias)
+        /// This is an existing supported scenario that should continue to work
+        /// </summary>
+        [Fact]
+        public void FetchXml_WithEntityNameNoAlias_ShouldWork()
+        {
+            _context.EnableProxyTypes(Assembly.GetAssembly(typeof(Contact)));
+
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                Id = accountId,
+                Name = "Test Account"
+            };
+
+            var contactId = Guid.NewGuid();
+            var contact = new Contact
+            {
+                Id = contactId,
+                FirstName = "John",
+                LastName = "Doe",
+                BirthDate = DateTime.Now.AddYears(-30),
+                ParentCustomerId = new EntityReference("account", accountId)
+            };
+
+            _context.Initialize(new List<Entity> { account, contact });
+
+            var service = _context.GetOrganizationService();
+
+            // FetchXML with entityname pointing to entity name (not alias)
+            var fetchXml = $@"
+                <fetch>
+                    <entity name='account'>
+                        <attribute name='name' />
+                        <filter>
+                            <condition attribute='birthdate' operator='not-null' 
+                                       entityname='contact' />
+                        </filter>
+                        <link-entity name='contact' 
+                                     from='parentcustomerid' 
+                                     to='accountid' 
+                                     link-type='inner'>
+                            <attribute name='firstname' />
+                            <attribute name='birthdate' />
+                        </link-entity>
+                    </entity>
+                </fetch>";
+
+            var result = service.RetrieveMultiple(new FetchExpression(fetchXml));
+
+            Assert.Single(result.Entities);
+            Assert.Equal(accountId, result.Entities[0].Id);
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**

FetchXML conditions with entityname attribute fail when the referenced attribute exists only on the linked entity, not the main entity. This occurs because attribute type lookup incorrectly uses the parent entity name instead of resolving the alias.

This PR provides the fix.

## Changes Made

### Core Fix (Applied to fake-xrm-easy-core)
- **Modified**: `src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs`
  - Added `ResolveAliasToEntityName` method to resolve alias to actual entity name
  - Updated `ToConditionExpression` to use resolved entity name for type lookup
- **Added**: `tests/FakeXrmEasy.Core.Tests/Query/FetchXml/FetchXmlAliasedConditionTests.cs`
  - Comprehensive tests for entityname alias scenarios
- **Added**: `aliasToEntityMap` dictionary which is scoped to a fetchxml query for quicker lookups once an alias or entityname has been resolved once.

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

