### PR TITLE
fix: fixes DynamicsValue/fake-xrm-easy#217

### DIFF
--- a/src/FakeXrmEasy.Core/Extensions/ObjectExtensions.cs
+++ b/src/FakeXrmEasy.Core/Extensions/ObjectExtensions.cs
@@ -51,6 +51,22 @@ namespace FakeXrmEasy.Extensions
         }
 
         /// <summary>
+        /// Determines whether the specified object contains a field with the given name.
+        /// </summary>
+        /// <param name="obj">The object to inspect for the presence of the field. Cannot be null.</param>
+        /// <param name="fieldName">The name of the field to search for. The comparison is case-sensitive.</param>
+        /// <returns>true if a field with the specified name exists on the object; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if obj is null.</exception>
+        public static bool HasField(this object obj, string fieldName)
+        {
+            if (obj == null)
+                throw new ArgumentNullException("obj");
+            Type objType = obj.GetType();
+            FieldInfo fieldInfo = GetFieldInfo(objType, fieldName);
+            return fieldInfo != null;
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="obj"></param>
@@ -65,8 +81,19 @@ namespace FakeXrmEasy.Extensions
             Type objType = obj.GetType();
             FieldInfo fieldInfo = GetFieldInfo(objType, fieldName);
             if (fieldInfo == null)
-                throw new ArgumentOutOfRangeException("fieldName",
-                  string.Format("Couldn't find field {0} in type {1}", fieldName, objType.FullName));
+            {
+                fieldInfo = GetFieldInfo(objType, "_inner");
+                if (fieldInfo == null)
+                {
+                    throw new ArgumentOutOfRangeException("fieldName",
+                string.Format("Couldn't find field {0} in type {1}", fieldName, objType.FullName));
+                }
+                else
+                {
+                    return GetFieldValue(fieldInfo.GetValue(obj), fieldName);
+                }
+            }
+
             return fieldInfo.GetValue(obj);
         }
 
@@ -85,8 +112,20 @@ namespace FakeXrmEasy.Extensions
             Type objType = obj.GetType();
             FieldInfo fieldInfo = GetFieldInfo(objType, fieldName);
             if (fieldInfo == null)
-                throw new ArgumentOutOfRangeException("fieldName",
-                  string.Format("Couldn't find field {0} in type {1}", fieldName, objType.FullName));
+            {
+                fieldInfo = GetFieldInfo(objType, "_inner") as FieldInfo;
+                if (fieldInfo == null)
+                {
+                    throw new ArgumentOutOfRangeException("fieldName",
+                      string.Format("Couldn't find field {0} in type {1}", fieldName, objType.FullName));
+                }
+                else
+                {
+                    SetFieldValue(fieldInfo.GetValue(obj), fieldName, val);
+                    return;
+                }
+            }
+
             fieldInfo.SetValue(obj, val);
         }
 

--- a/tests/FakeXrmEasy.Core.Tests/FakeXrmEasy.Core.Tests.csproj
+++ b/tests/FakeXrmEasy.Core.Tests/FakeXrmEasy.Core.Tests.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' And '$(Configuration)'=='FAKE_XRM_EASY_9'">
-    <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.52" />
+    <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.60" />
     <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.1.45" />
   </ItemGroup>
 


### PR DESCRIPTION
**What issue does this PR address?**
Hi @jordimontana82,
this fixes issue DynamicsValue/fake-xrm-easy#217 

Since MS hid the Metadata private fields to a private class stored in the `_inner` field, this was the quickest solution I could think of that is backwards compatible.

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

