### PR TITLE
Adds proper exception raised when a join operator in a fetchxml query…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.9.4]
+
+### Changed
+
+- Resolves edge case in All, NotAll, Any, NotAny Join operators - https://github.com/DynamicsValue/fake-xrm-easy/issues/260
+
 ## [2.9.3]
 
 ### Changed

--- a/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
+++ b/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
@@ -363,16 +363,17 @@ namespace FakeXrmEasy.Extensions.FetchXml
         {
             if (el.GetAttribute("link-type") != null)
             {
-                switch (el.GetAttribute("link-type").Value)
+                var linkType = el.GetAttribute("link-type").Value;
+                switch (linkType)
                 {
                     #if FAKE_XRM_EASY_9
                     case "all":
                         return JoinOperator.All;
-                    case "not-all":
+                    case "not all":
                         return JoinOperator.NotAll;
                     case "any":
                         return JoinOperator.Any;
-                    case "not-any":
+                    case "not any":
                         return JoinOperator.NotAny;
                     case "exists":
                         return JoinOperator.Exists;
@@ -382,7 +383,8 @@ namespace FakeXrmEasy.Extensions.FetchXml
                     case "outer":
                         return JoinOperator.LeftOuter;
                     default:
-                        return JoinOperator.Inner;
+                        throw FakeOrganizationServiceFaultFactory.New(ErrorCodes.QueryBuilderDeserializeInvalidLinkType,
+                            $"Invalid link-type specified, valid values are: 'natural', 'inner', 'in', 'matchfirstrowusingcrossapply','exists' and 'outer'. link-type = {linkType}");
                 }
             }
             return JoinOperator.Inner;

--- a/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
+++ b/src/FakeXrmEasy.Core/Extensions/XmlExtensionsForFetchXml.cs
@@ -380,6 +380,10 @@ namespace FakeXrmEasy.Extensions.FetchXml
                     case "in":
                         return JoinOperator.In;
                     #endif
+                    case "natural":
+                        return JoinOperator.Natural;
+                    case "inner":
+                        return JoinOperator.Inner;
                     case "outer":
                         return JoinOperator.LeftOuter;
                     default:

--- a/src/FakeXrmEasy.Core/Query/LinkEntityQueryExtensions.cs
+++ b/src/FakeXrmEasy.Core/Query/LinkEntityQueryExtensions.cs
@@ -97,6 +97,7 @@ namespace FakeXrmEasy.Query
                 #endif
                 
                 default: //This shouldn't be reached unless a new operator is added...
+                    
                     throw UnsupportedExceptionFactory.New(context.LicenseContext.Value, string.Format("The join operator {0} is currently not supported. ", le.JoinOperator));
 
             }

--- a/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/InvalidOperatorTests.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/InvalidOperatorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using DataverseEntities;
+using FakeXrmEasy.Abstractions;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+#if FAKE_XRM_EASY_9
+namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
+{
+    public class InvalidOperatorTests : FakeXrmEasyTestsBase
+    {
+        private readonly Contact _contact;
+        private readonly Account _contosoAccount;
+        private readonly Account _contAccount;
+
+        public InvalidOperatorTests()
+        {
+            _contact = new Contact()
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "Joe"
+            };
+
+            _contosoAccount = new Account()
+            {
+                Id = Guid.NewGuid(),
+                Name = "Contoso",
+                PrimaryContactId = _contact.ToEntityReference()
+            };
+
+            _contAccount = new Account()
+            {
+                Id = Guid.NewGuid(),
+                Name = "Cont",
+                PrimaryContactId = _contact.ToEntityReference()
+            };
+        }
+        
+        [Fact]
+        public void Should_throw_exception_with_an_invalid_join_operator()
+        {
+            _context.Initialize(new List<Entity>() {_contact, _contosoAccount });
+            
+            var fetch = @"
+                    <fetch distinct='false' useraworderby='false' no-lock='false' mapping='logical'>
+                        <entity name='contact'>
+                            <attribute name='firstname' />
+                            <filter type='or'>
+                                <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-all'>
+                                    <filter type='and'>
+                                        <condition attribute='name' operator='eq' value='Other name' />
+                                    </filter>
+                                </link-entity>
+                            </filter>
+                        </entity>
+                    </fetch>
+                ";
+
+            var ex = XAssert.ThrowsFaultCode(ErrorCodes.QueryBuilderDeserializeInvalidLinkType, () => _service.RetrieveMultiple(new FetchExpression(fetch)));
+            Assert.Equal($"Invalid link-type specified, valid values are: 'natural', 'inner', 'in', 'matchfirstrowusingcrossapply','exists' and 'outer'. link-type = not-all", ex.Message);
+        }
+    }
+}
+#endif

--- a/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/NotAllOperatorTests.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/NotAllOperatorTests.cs
@@ -15,7 +15,6 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
         private readonly Contact _contact;
         private readonly Account _contosoAccount;
         private readonly Account _contAccount;
-        
         public NotAllOperatorTests()
         {
             _contact = new Contact()
@@ -50,7 +49,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-all'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not all'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Contoso' />
                                 </filter>
@@ -93,7 +92,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-all'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not all'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Contoso' />
                                 </filter>
@@ -119,7 +118,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-all'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not all'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='begins-with' value='Cont' />
                                 </filter>
@@ -147,7 +146,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-all'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not all'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Cont' />
                                     <condition attribute='name' operator='eq' value='Some other' />

--- a/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/NotAnyOperatorTests.cs
+++ b/tests/FakeXrmEasy.Core.Tests/Query/FetchXml/JoinOperatorTests/NotAnyOperatorTests.cs
@@ -50,7 +50,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-any'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not any'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Other name' />
                                 </filter>
@@ -93,7 +93,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-any'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not any'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Other name' />
                                 </filter>
@@ -119,7 +119,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-any'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not any'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Contoso' />
                                 </filter>
@@ -144,7 +144,7 @@ namespace FakeXrmEasy.Core.Tests.Query.FetchXml.JoinOperatorTests
                         <entity name='contact'>
                             <attribute name='firstname' />
                         <filter type='or'>
-                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not-any'>
+                            <link-entity name='account' to='contactid' from='primarycontactid' link-type='not any'>
                                 <filter type='and'>
                                     <condition attribute='name' operator='eq' value='Other name' />
                                 </filter>


### PR DESCRIPTION
… is invalid. Fixes not-all and not-any operators that should not use hyphen (-) but a whitespace instead DynamicsValue/fake-xrm-easy#260

**What issue does this PR address?**


**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

